### PR TITLE
sb.bat works in windows 8.1

### DIFF
--- a/src/main/scripts/sb.bat
+++ b/src/main/scripts/sb.bat
@@ -14,6 +14,6 @@ EXIT /B 1
 :savantHomeSet
 SET CLASSPATH=
 FOR %%f IN ("%SAVANT_HOME%\lib\*.jar") DO SET CLASSPATH=%%f;!CLASSPATH!
-java "SAVANT_OPTS" -cp "%CLASSPATH%" org.savantbuild.run.Main %*
+java %SAVANT_OPTS% -cp "%CLASSPATH%" org.savantbuild.run.Main %*
 
 ENDLOCAL


### PR DESCRIPTION
When I commanded "sb.bat", Then console showed "Error “main class not found”"

In sb.bat, 
Did you mean, is 'java "SAVANT_OPTS"' is 'java %SAVANT_OPTS%' ?
