### PR TITLE
Fixes path to main on Windows

### DIFF
--- a/src/main/scripts/sb.bat
+++ b/src/main/scripts/sb.bat
@@ -19,6 +19,6 @@ EXIT /B 1
 :savantHomeSet
 SET CLASSPATH=
 FOR %%f IN ("%SAVANT_HOME%\lib\*.jar") DO SET CLASSPATH=%%f;!CLASSPATH!
-%JAVA_HOME%\bin\java %SAVANT_OPTS% -cp "%CLASSPATH%" org.savantbuild.run.Main %*
+%JAVA_HOME%\bin\java %SAVANT_OPTS% -cp "%CLASSPATH%" org.savantbuild.runtime.Main %*
 
 ENDLOCAL


### PR DESCRIPTION
Noticed that there was a difference in the main class pathing between the windows and bash scripts, which led to the following error when attempting to build `FusionAuth/fusionauth-example-password-encryptor`:

```
Error: Could not find or load main class org.savantbuild.run.Main
```