### PR TITLE
Allow having direct dependencies use semantic version mapping

### DIFF
--- a/build.savant
+++ b/build.savant
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Inversoft Inc., All Rights Reserved
+ * Copyright (c) 2014-2024, Inversoft Inc., All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/build.savant
+++ b/build.savant
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2022, Inversoft Inc., All Rights Reserved
+ * Copyright (c) 2024, Inversoft Inc., All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
  * either express or implied. See the License for the specific
  * language governing permissions and limitations under the License.
  */
-project(group: "org.savantbuild", name: "savant-core", version: "2.0.0-RC.6", licenses: ["Apache-2.0"]) {
+project(group: "org.savantbuild", name: "savant-core", version: "2.0.0-RC.7", licenses: ["Apache-2.0"]) {
   workflow {
     fetch {
       cache()
@@ -66,9 +66,9 @@ project(group: "org.savantbuild", name: "savant-core", version: "2.0.0-RC.6", li
 //      dependency(id: "org.apache.groovy:groovy-templates:4.0.6:jar")
 //      dependency(id: "org.apache.groovy:groovy-xml:4.0.6:jar")
 //      dependency(id: "org.apache.groovy:groovy-yaml:4.0.6:jar")
-      dependency(id: "org.savantbuild:savant-dependency-management:2.0.0-RC.6")
-      dependency(id: "org.savantbuild:savant-utils:2.0.0-RC.6")
-      dependency(id: "org.savantbuild:savant-version:2.0.0-RC.6")
+      dependency(id: "org.savantbuild:savant-dependency-management:2.0.0-RC.7")
+      dependency(id: "org.savantbuild:savant-utils:2.0.0-RC.7")
+      dependency(id: "org.savantbuild:savant-version:2.0.0-RC.7")
     }
     group(name: "test-compile", export: false) {
       dependency(id: "org.easymock:easymock:3.2")
@@ -85,20 +85,20 @@ project(group: "org.savantbuild", name: "savant-core", version: "2.0.0-RC.6", li
 }
 
 // Plugins
-dependency = loadPlugin(id: "org.savantbuild.plugin:dependency:2.0.0-RC.6")
-file = loadPlugin(id: "org.savantbuild.plugin:file:2.0.0-RC.6")
-java = loadPlugin(id: "org.savantbuild.plugin:java:2.0.0-RC.6")
-javaTestNG = loadPlugin(id: "org.savantbuild.plugin:java-testng:2.0.0-RC.6")
-idea = loadPlugin(id: "org.savantbuild.plugin:idea:2.0.0-RC.6")
-release = loadPlugin(id: "org.savantbuild.plugin:release-git:2.0.0-RC.6")
+dependency = loadPlugin(id: "org.savantbuild.plugin:dependency:2.0.0-RC.7")
+file = loadPlugin(id: "org.savantbuild.plugin:file:2.0.0-RC.7")
+java = loadPlugin(id: "org.savantbuild.plugin:java:2.0.0-RC.7")
+javaTestNG = loadPlugin(id: "org.savantbuild.plugin:java-testng:2.0.0-RC.7")
+idea = loadPlugin(id: "org.savantbuild.plugin:idea:2.0.0-RC.7")
+release = loadPlugin(id: "org.savantbuild.plugin:release-git:2.0.0-RC.7")
 
 // Plugin settings
 java.settings.javaVersion = "17"
 javaTestNG.settings.javaVersion = "17"
 idea.settings.moduleMap = [
-    "org.savantbuild:savant-dependency-management:2.0.0-RC.6" : "savant-dependency-management",
-    "org.savantbuild:savant-utils:2.0.0-RC.6"                 : "savant-utils",
-    "org.savantbuild:savant-version:2.0.0-RC.6"               : "savant-version"
+    "org.savantbuild:savant-dependency-management:2.0.0-RC.7": "savant-dependency-management",
+    "org.savantbuild:savant-utils:2.0.0-RC.7"                : "savant-utils",
+    "org.savantbuild:savant-version:2.0.0-RC.7"              : "savant-version"
 ]
 
 target(name: "clean", description: "Cleans the project") {

--- a/src/main/java/org/savantbuild/parser/groovy/DependenciesDelegate.java
+++ b/src/main/java/org/savantbuild/parser/groovy/DependenciesDelegate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Inversoft Inc., All Rights Reserved
+ * Copyright (c) 2013-2024, Inversoft Inc., All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/savantbuild/parser/groovy/DependenciesDelegate.java
+++ b/src/main/java/org/savantbuild/parser/groovy/DependenciesDelegate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, Inversoft Inc., All Rights Reserved
+ * Copyright (c) 2024, Inversoft Inc., All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ import java.util.Map;
 
 import org.savantbuild.dep.domain.Dependencies;
 import org.savantbuild.dep.domain.DependencyGroup;
+import org.savantbuild.domain.Version;
 import org.savantbuild.parser.ParseException;
 
 import groovy.lang.Closure;
@@ -32,8 +33,12 @@ import groovy.lang.DelegatesTo;
 public class DependenciesDelegate {
   private final Dependencies dependencies;
 
-  public DependenciesDelegate(Dependencies dependencies) {
+  private final Map<String, Version> semanticVersionMappings;
+
+  public DependenciesDelegate(Dependencies dependencies,
+                              Map<String, Version> semanticVersionMappings) {
     this.dependencies = dependencies;
+    this.semanticVersionMappings = semanticVersionMappings;
   }
 
   /**
@@ -57,7 +62,7 @@ public class DependenciesDelegate {
     DependencyGroup group = new DependencyGroup(name, export);
     dependencies.groups.put(name, group);
 
-    closure.setDelegate(new DependencyDelegate(group));
+    closure.setDelegate(new DependencyDelegate(group, semanticVersionMappings));
     closure.setResolveStrategy(Closure.DELEGATE_FIRST);
     closure.run();
 

--- a/src/main/java/org/savantbuild/parser/groovy/DependencyDelegate.java
+++ b/src/main/java/org/savantbuild/parser/groovy/DependencyDelegate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Inversoft Inc., All Rights Reserved
+ * Copyright (c) 2014-2024, Inversoft Inc., All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/savantbuild/parser/groovy/DependencyDelegate.java
+++ b/src/main/java/org/savantbuild/parser/groovy/DependencyDelegate.java
@@ -98,6 +98,15 @@ public class DependencyDelegate {
       return;
     }
 
+    // we want the semanticVersions/DSL to function the same way in all cases
+    // meaning mapping(id: "net.sf.saxon:Saxon-HE:10.9", version: "10.9.0")
+    // where 10.9 is the bad version
+
+    // and we want the actual dependency specs to be "good" versions, e.g.
+    // dependency(id: "net.sf.saxon:Saxon-HE:10.9.0")
+
+    // therefore, when we are handling a direct dependency, we have to swap our mapping
+    // and use the good versions as the keys and the bad versions as the values
     Function<String, String> getWithoutVersion = artifact -> {
       var id = new ArtifactSpec(artifact, false).id;
       return id.group + ":" + id.name;

--- a/src/main/java/org/savantbuild/parser/groovy/ProjectDelegate.java
+++ b/src/main/java/org/savantbuild/parser/groovy/ProjectDelegate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Inversoft Inc., All Rights Reserved
+ * Copyright (c) 2013-2024, Inversoft Inc., All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/savantbuild/parser/groovy/ProjectDelegate.java
+++ b/src/main/java/org/savantbuild/parser/groovy/ProjectDelegate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, Inversoft Inc., All Rights Reserved
+ * Copyright (c) 2024, Inversoft Inc., All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -71,7 +71,7 @@ public class ProjectDelegate {
     }
 
     project.dependencies = new Dependencies();
-    closure.setDelegate(new DependenciesDelegate(project.dependencies));
+    closure.setDelegate(new DependenciesDelegate(project.dependencies, project.workflow.mappings));
     closure.setResolveStrategy(Closure.DELEGATE_FIRST);
     closure.run();
     return project.dependencies;

--- a/src/test/java/org/savantbuild/parser/groovy/GroovyBuildFileParserTest.java
+++ b/src/test/java/org/savantbuild/parser/groovy/GroovyBuildFileParserTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Inversoft Inc., All Rights Reserved
+ * Copyright (c) 2014-2024, Inversoft Inc., All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/savantbuild/parser/groovy/simple.savant
+++ b/src/test/java/org/savantbuild/parser/groovy/simple.savant
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2024, Inversoft Inc., All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
 package org.savantbuild.parser.groovy
 
 project(group: "group", name: "name", version: "1.1", licenses: ["ApacheV2_0", "Apache-1.0", "BSD-2-Clause", "Commercial"]) {
@@ -14,6 +29,7 @@ project(group: "group", name: "name", version: "1.1", licenses: ["ApacheV2_0", "
     }
     semanticVersions {
       mapping(id: "org.badver:badver:1.0.0.Final", version: "1.0.0")
+      mapping(id: "org.badver:directbadver:1.0", version: "1.0.0")
     }
   }
 
@@ -28,6 +44,7 @@ project(group: "group", name: "name", version: "1.1", licenses: ["ApacheV2_0", "
         exclusion(id: "org.example:exclude-2:zip")
         exclusion(id: "org.example:exclude-3:exclude-4:xml")
       }
+      dependency(id: "org.badver:directbadver:1.0.0")
     }
     group(name: "test-compile", export: false) {
       dependency(id: "org.example:test:1.0")

--- a/src/test/java/org/savantbuild/runtime/MainTest.java
+++ b/src/test/java/org/savantbuild/runtime/MainTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Inversoft Inc., All Rights Reserved
+ * Copyright (c) 2014-2024, Inversoft Inc., All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/savantbuild/runtime/MainTest.java
+++ b/src/test/java/org/savantbuild/runtime/MainTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Inversoft Inc., All Rights Reserved
+ * Copyright (c) 2024, Inversoft Inc., All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,18 +42,18 @@ public class MainTest extends BaseUnitTest {
     ArtifactID multipleVersionsDifferentDeps = new ArtifactID("org.savantbuild.test", "multiple-versions-different-dependencies", "multiple-versions-different-dependencies", "jar");
 
     DependencyGraph incompatible = new DependencyGraph(project);
-    incompatible.addEdge(new Dependency(project.id), new Dependency(multipleVersions), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "compile", new License()));
-    incompatible.addEdge(new Dependency(project.id), new Dependency(intermediate), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "runtime", new License()));
-    incompatible.addEdge(new Dependency(project.id), new Dependency(multipleVersionsDifferentDeps), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "compile", new License()));
-    incompatible.addEdge(new Dependency(intermediate), new Dependency(multipleVersions), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.1.0"), "compile", new License()));
-    incompatible.addEdge(new Dependency(intermediate), new Dependency(multipleVersionsDifferentDeps), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.1.0"), "runtime", new License()));
-    incompatible.addEdge(new Dependency(multipleVersions), new Dependency(leaf), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "compile", new License()));
-    incompatible.addEdge(new Dependency(multipleVersions), new Dependency(leaf), new DependencyEdgeValue(new Version("1.1.0"), new Version("1.0.0"), "compile", new License()));
-    incompatible.addEdge(new Dependency(multipleVersionsDifferentDeps), new Dependency(leaf), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "runtime", new License()));
-    incompatible.addEdge(new Dependency(multipleVersionsDifferentDeps), new Dependency(leaf), new DependencyEdgeValue(new Version("1.1.0"), new Version("2.0.0"), "compile", new License()));
+    incompatible.addEdge(new Dependency(project.id, project.nonSemanticVersion), new Dependency(multipleVersions, null), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "compile", new License()));
+    incompatible.addEdge(new Dependency(project.id, project.nonSemanticVersion), new Dependency(intermediate, null), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "runtime", new License()));
+    incompatible.addEdge(new Dependency(project.id, project.nonSemanticVersion), new Dependency(multipleVersionsDifferentDeps, null), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "compile", new License()));
+    incompatible.addEdge(new Dependency(intermediate, null), new Dependency(multipleVersions, null), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.1.0"), "compile", new License()));
+    incompatible.addEdge(new Dependency(intermediate, null), new Dependency(multipleVersionsDifferentDeps, null), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.1.0"), "runtime", new License()));
+    incompatible.addEdge(new Dependency(multipleVersions, null), new Dependency(leaf, null), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "compile", new License()));
+    incompatible.addEdge(new Dependency(multipleVersions, null), new Dependency(leaf, null), new DependencyEdgeValue(new Version("1.1.0"), new Version("1.0.0"), "compile", new License()));
+    incompatible.addEdge(new Dependency(multipleVersionsDifferentDeps, null), new Dependency(leaf, null), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "runtime", new License()));
+    incompatible.addEdge(new Dependency(multipleVersionsDifferentDeps, null), new Dependency(leaf, null), new DependencyEdgeValue(new Version("1.1.0"), new Version("2.0.0"), "compile", new License()));
 
     output = new SystemOutOutput(true);
-    Main.printCompatibilityError(new CompatibilityException(incompatible, new Dependency(leaf), new Version("1.0.0"), new Version("2.0.0")), output);
+    Main.printCompatibilityError(new CompatibilityException(incompatible, new Dependency(leaf, null), new Version("1.0.0"), new Version("2.0.0")), output);
   }
 
   @Test(enabled = false)


### PR DESCRIPTION
Until now, only transitive dependencies could take advantage of this. Without this, you need to publish a package to a repo with a different version if, for example, the package version in Maven central that you need is 1.0. You'd have to publish a copy under 1.0.0.

There might be better ways to do this, but it's a start.

The `MainTest` updates in here are side effects of the dependent PR mentioned below.

Depends on https://github.com/savant-build/savant-dependency-management/pull/5