### PR TITLE
Update dep for savant-dependency-management

### DIFF
--- a/build.savant
+++ b/build.savant
@@ -73,7 +73,7 @@ release = loadPlugin(id: "org.savantbuild.plugin:release-git:2.0.0")
 java.settings.javaVersion = "17"
 javaTestNG.settings.javaVersion = "17"
 idea.settings.moduleMap = [
-    "org.savantbuild:savant-dependency-management:${savantVersion}": "savant-dependency-management",
+    "org.savantbuild:savant-dependency-management:2.0.2-{integration}": "savant-dependency-management",
     "org.savantbuild:savant-utils:${savantVersion}"                : "savant-utils",
     "org.savantbuild:savant-version:${savantVersion}"              : "savant-version"
 ]

--- a/build.savant
+++ b/build.savant
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2024, Inversoft Inc., All Rights Reserved
+ * Copyright (c) 2014-2025, Inversoft Inc., All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * language governing permissions and limitations under the License.
  */
 savantVersion = "2.0.0"
-project(group: "org.savantbuild", name: "savant-core", version: "2.0.1", licenses: ["Apache-2.0"]) {
+project(group: "org.savantbuild", name: "savant-core", version: "2.0.2", licenses: ["Apache-2.0"]) {
   workflow {
     fetch {
       cache()
@@ -43,7 +43,7 @@ project(group: "org.savantbuild", name: "savant-core", version: "2.0.1", license
       dependency(id: "org.apache.groovy:groovy-templates:4.0.22:jar")
       dependency(id: "org.apache.groovy:groovy-xml:4.0.22:jar")
       dependency(id: "org.apache.groovy:groovy-yaml:4.0.22:jar")
-      dependency(id: "org.savantbuild:savant-dependency-management:2.0.1")
+      dependency(id: "org.savantbuild:savant-dependency-management:2.0.2-{integration}")
       dependency(id: "org.savantbuild:savant-utils:2.0.1")
       dependency(id: "org.savantbuild:savant-version:${savantVersion}")
     }

--- a/build.savant
+++ b/build.savant
@@ -43,7 +43,7 @@ project(group: "org.savantbuild", name: "savant-core", version: "2.0.2", license
       dependency(id: "org.apache.groovy:groovy-templates:4.0.22:jar")
       dependency(id: "org.apache.groovy:groovy-xml:4.0.22:jar")
       dependency(id: "org.apache.groovy:groovy-yaml:4.0.22:jar")
-      dependency(id: "org.savantbuild:savant-dependency-management:2.0.2-{integration}")
+      dependency(id: "org.savantbuild:savant-dependency-management:2.0.2")
       dependency(id: "org.savantbuild:savant-utils:2.0.1")
       dependency(id: "org.savantbuild:savant-version:${savantVersion}")
     }
@@ -73,7 +73,7 @@ release = loadPlugin(id: "org.savantbuild.plugin:release-git:2.0.0")
 java.settings.javaVersion = "17"
 javaTestNG.settings.javaVersion = "17"
 idea.settings.moduleMap = [
-    "org.savantbuild:savant-dependency-management:2.0.2-{integration}": "savant-dependency-management",
+    "org.savantbuild:savant-dependency-management:2.0.2": "savant-dependency-management",
     "org.savantbuild:savant-utils:${savantVersion}"                : "savant-utils",
     "org.savantbuild:savant-version:${savantVersion}"              : "savant-version"
 ]

--- a/savant-core.iml
+++ b/savant-core.iml
@@ -147,11 +147,11 @@
     <orderEntry type="module-library">
       <library>
         <CLASSES>
-          <root url="jar://$MODULE_DIR$/.savant/cache/org/savantbuild/savant-dependency-management/2.0.1/savant-dependency-management-2.0.1.jar!/" />
+          <root url="jar://$USER_HOME$/.savant/cache/org/savantbuild/savant-dependency-management/2.0.2-{integration}/savant-dependency-management-2.0.2-{integration}.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$MODULE_DIR$/.savant/cache/org/savantbuild/savant-dependency-management/2.0.1/savant-dependency-management-2.0.1-src.jar!/" />
+          <root url="jar://$USER_HOME$/.savant/cache/org/savantbuild/savant-dependency-management/2.0.2-{integration}/savant-dependency-management-2.0.2-{integration}-src.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>

--- a/savant-core.iml
+++ b/savant-core.iml
@@ -144,17 +144,7 @@
         </SOURCES>
       </library>
     </orderEntry>
-    <orderEntry type="module-library">
-      <library>
-        <CLASSES>
-          <root url="jar://$USER_HOME$/.savant/cache/org/savantbuild/savant-dependency-management/2.0.2-{integration}/savant-dependency-management-2.0.2-{integration}.jar!/" />
-        </CLASSES>
-        <JAVADOC />
-        <SOURCES>
-          <root url="jar://$USER_HOME$/.savant/cache/org/savantbuild/savant-dependency-management/2.0.2-{integration}/savant-dependency-management-2.0.2-{integration}-src.jar!/" />
-        </SOURCES>
-      </library>
-    </orderEntry>
+    <orderEntry type="module" module-name="savant-dependency-management" />
     <orderEntry type="module-library">
       <library>
         <CLASSES>

--- a/src/main/java/org/savantbuild/parser/groovy/SemanticVersionDelegate.java
+++ b/src/main/java/org/savantbuild/parser/groovy/SemanticVersionDelegate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Inversoft Inc., All Rights Reserved
+ * Copyright (c) 2022-2025, Inversoft Inc., All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,8 +28,11 @@ import org.savantbuild.parser.ParseException;
 public class SemanticVersionDelegate {
   public final Map<String, Version> mapping;
 
-  public SemanticVersionDelegate(Map<String, Version> mapping) {
+  public final Map<String, String> rangeMapping;
+
+  public SemanticVersionDelegate(Map<String, Version> mapping, Map<String, String> rangeMapping) {
     this.mapping = mapping;
+    this.rangeMapping = rangeMapping;
   }
 
   public void mapping(Map<String, Object> attributes) {
@@ -41,5 +44,16 @@ public class SemanticVersionDelegate {
     String id = GroovyTools.toString(attributes, "id");
     String version = GroovyTools.toString(attributes, "version");
     mapping.put(id, new Version(version));
+  }
+
+  public void rangeMapping(Map<String, Object> attributes) {
+    if (!GroovyTools.hasAttributes(attributes, "id", "version")) {
+      throw new ParseException("Invalid mapping definition. It must have an [id] and a [version] attribute like this:\n\n" +
+          "  mapping(id: \"org.range:mc-range-face:[1.0,2.0)\", version: \"1.0\")");
+    }
+
+    String id = GroovyTools.toString(attributes, "id");
+    String version = GroovyTools.toString(attributes, "version");
+    rangeMapping.put(id, version);
   }
 }

--- a/src/main/java/org/savantbuild/parser/groovy/SemanticVersionDelegate.java
+++ b/src/main/java/org/savantbuild/parser/groovy/SemanticVersionDelegate.java
@@ -37,8 +37,11 @@ public class SemanticVersionDelegate {
 
   public void mapping(Map<String, Object> attributes) {
     if (!GroovyTools.hasAttributes(attributes, "id", "version")) {
-      throw new ParseException("Invalid mapping definition. It must have an [id] and a [version] attribute like this:\n\n" +
-          "  mapping(id: \"org.badver:badver:1.0.0.Final\", version: \"1.0.0\")");
+      throw new ParseException("""
+          Invalid mapping definition. It must have an [id] and a [version] attribute like this:
+          
+            mapping(id: "org.badver:badver:1.0.0.Final", version: "1.0.0")
+          """);
     }
 
     String id = GroovyTools.toString(attributes, "id");
@@ -48,8 +51,14 @@ public class SemanticVersionDelegate {
 
   public void rangeMapping(Map<String, Object> attributes) {
     if (!GroovyTools.hasAttributes(attributes, "id", "version")) {
-      throw new ParseException("Invalid mapping definition. It must have an [id] and a [version] attribute like this:\n\n" +
-          "  mapping(id: \"org.range:mc-range-face:[1.0,2.0)\", version: \"1.0\")");
+      throw new ParseException("""
+          Invalid rangeMapping definition. It must have an [id] and a [version] attribute like this:
+          
+            rangeMapping(id: "org.range:mc-range-face:[1.0,2.0)", version: "1.0")
+          
+          Note, the version should be a concrete version found in the Maven repository. If this version is not
+          semantic, it is possible you will also require a version mapping.
+          """);
     }
 
     String id = GroovyTools.toString(attributes, "id");

--- a/src/main/java/org/savantbuild/parser/groovy/WorkflowDelegate.java
+++ b/src/main/java/org/savantbuild/parser/groovy/WorkflowDelegate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, Inversoft Inc., All Rights Reserved
+ * Copyright (c) 2013-2025, Inversoft Inc., All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -88,7 +88,7 @@ public class WorkflowDelegate {
    * @return The mappings.
    */
   public Map<String, Version> semanticVersions(@DelegatesTo(SemanticVersionDelegate.class) Closure<?> closure) {
-    closure.setDelegate(new SemanticVersionDelegate(workflow.mappings));
+    closure.setDelegate(new SemanticVersionDelegate(workflow.mappings, workflow.rangeMappings));
     closure.setResolveStrategy(Closure.DELEGATE_FIRST);
     closure.run();
     return workflow.mappings;


### PR DESCRIPTION
### Summary
Update dep to pick up related PR. 

- Changes from `avant-dependency-management` include support for maven version ranges via mapping, and improved performance when using maven semantic version mappings. 

### Related
- https://github.com/savant-build/savant-dependency-management/pull/7