### PR TITLE
Use SavantPaths for XDG directory resolution

### DIFF
--- a/build.savant
+++ b/build.savant
@@ -13,8 +13,8 @@
  * either express or implied. See the License for the specific
  * language governing permissions and limitations under the License.
  */
-savantVersion = "2.1.0"
-project(group: "org.savantbuild", name: "savant-core", version: "2.1.0", licenses: ["Apache-2.0"]) {
+savantVersion = "2.2.0-{integration}"
+project(group: "org.savantbuild", name: "savant-core", version: "2.2.0", licenses: ["Apache-2.0"]) {
   workflow {
     fetch {
       cache()

--- a/src/main/java/org/savantbuild/domain/Project.java
+++ b/src/main/java/org/savantbuild/domain/Project.java
@@ -16,7 +16,6 @@
 package org.savantbuild.domain;
 
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -34,6 +33,7 @@ import org.savantbuild.dep.workflow.Workflow;
 import org.savantbuild.output.Output;
 import org.savantbuild.plugin.Plugin;
 import org.savantbuild.util.Graph;
+import org.savantbuild.util.SavantPaths;
 
 /**
  * This class defines the project.
@@ -61,7 +61,7 @@ public class Project {
 
   public String name;
 
-  public Path pluginConfigurationDirectory = Paths.get(System.getProperty("user.home") + "/.savant/plugins");
+  public Path pluginConfigurationDirectory = SavantPaths.get().configDir().resolve("plugins");
 
   public Map<Artifact, Plugin> plugins = new HashMap<>();
 

--- a/src/main/java/org/savantbuild/parser/groovy/GlobalConfiguration.java
+++ b/src/main/java/org/savantbuild/parser/groovy/GlobalConfiguration.java
@@ -19,10 +19,10 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Properties;
 
 import org.savantbuild.runtime.BuildFailureException;
+import org.savantbuild.util.SavantPaths;
 
 import groovy.lang.GroovyObjectSupport;
 
@@ -37,12 +37,12 @@ public class GlobalConfiguration extends GroovyObjectSupport {
   public final Properties properties = new Properties();
 
   public GlobalConfiguration() {
-    Path configFile = Paths.get(System.getProperty("user.home"), ".savant/config.properties");
+    Path configFile = SavantPaths.get().configDir().resolve("config.properties");
     if (Files.isRegularFile(configFile)) {
       try (InputStream is = Files.newInputStream(configFile)) {
         properties.load(is);
       } catch (IOException e) {
-        throw new BuildFailureException("Unable to load global configuration file ~/.savant/config.properties", e);
+        throw new BuildFailureException("Unable to load global configuration file " + configFile, e);
       }
     }
   }
@@ -51,8 +51,9 @@ public class GlobalConfiguration extends GroovyObjectSupport {
   public Object getProperty(String property) {
     String value = properties.getProperty(property);
     if (value == null) {
+      Path configFile = SavantPaths.get().configDir().resolve("config.properties");
       throw new BuildFailureException("Missing global configuration property [" + property + "]. You must define this " +
-          "property in the global configuration file ~/.savant/config.properties");
+          "property in the global configuration file " + configFile);
     }
 
     return value;

--- a/src/main/java/org/savantbuild/parser/groovy/GlobalConfiguration.java
+++ b/src/main/java/org/savantbuild/parser/groovy/GlobalConfiguration.java
@@ -27,9 +27,9 @@ import org.savantbuild.util.SavantPaths;
 import groovy.lang.GroovyObjectSupport;
 
 /**
- * This class loads an optional global configuration file named config.properties in the ~/.savant/ directory. This is a
- * dynamic Groovy object that fails if lookups fail. This ensures that values from the configuration that the project
- * depends on exist.
+ * This class loads an optional global configuration file named config.properties in the XDG config directory
+ * ($XDG_CONFIG_HOME/savant/ or ~/.config/savant/). This is a dynamic Groovy object that fails if lookups fail. This
+ * ensures that values from the configuration that the project depends on exist.
  *
  * @author Brian Pontarelli
  */

--- a/src/main/java/org/savantbuild/parser/groovy/WorkflowDelegate.java
+++ b/src/main/java/org/savantbuild/parser/groovy/WorkflowDelegate.java
@@ -29,6 +29,7 @@ import org.savantbuild.dep.workflow.process.URLProcess;
 import org.savantbuild.domain.Version;
 import org.savantbuild.output.Output;
 import org.savantbuild.parser.ParseException;
+import org.savantbuild.util.SavantPaths;
 
 import groovy.lang.Closure;
 import groovy.lang.DelegatesTo;
@@ -40,8 +41,6 @@ import groovy.lang.DelegatesTo;
  * @author Brian Pontarelli
  */
 public class WorkflowDelegate {
-  public static final String defaultSavantDir = System.getProperty("user.home") + "/.savant/cache";
-
   public static final String defaultMavenDir = System.getProperty("user.home") + "/.m2/repository";
 
   public final Output output;
@@ -113,10 +112,11 @@ public class WorkflowDelegate {
    * </pre>
    */
   public void standard() {
-    workflow.fetchWorkflow.processes.add(new CacheProcess(output, defaultSavantDir, defaultSavantDir, defaultMavenDir));
+    String savantCache = SavantPaths.get().cacheDir().toString();
+    workflow.fetchWorkflow.processes.add(new CacheProcess(output, savantCache, savantCache, defaultMavenDir));
     workflow.fetchWorkflow.processes.add(new URLProcess(output, "https://repository.savantbuild.org", null, null));
     workflow.fetchWorkflow.processes.add(new MavenProcess(output, "https://repo1.maven.org/maven2", null, null));
-    workflow.publishWorkflow.processes.add(new CacheProcess(output, defaultSavantDir, defaultSavantDir, defaultMavenDir));
+    workflow.publishWorkflow.processes.add(new CacheProcess(output, savantCache, savantCache, defaultMavenDir));
   }
 
   /**
@@ -145,9 +145,10 @@ public class WorkflowDelegate {
       String dir = GroovyTools.toString(attributes, "dir");
       String intDir = GroovyTools.toString(attributes, "integrationDir");
       String mavenDir = GroovyTools.toString(attributes, "mavenDir");
+      String savantCache = SavantPaths.get().cacheDir().toString();
       processes.add(new CacheProcess(output,
-          dir != null ? dir : defaultSavantDir,
-          intDir != null ? intDir : defaultSavantDir,
+          dir != null ? dir : savantCache,
+          intDir != null ? intDir : savantCache,
           mavenDir != null ? mavenDir : defaultMavenDir));
     }
 
@@ -174,9 +175,10 @@ public class WorkflowDelegate {
     public void mavenCache(Map<String, Object> attributes) {
       String dir = GroovyTools.toString(attributes, "dir");
       String intDir = GroovyTools.toString(attributes, "integrationDir");
+      String savantCache = SavantPaths.get().cacheDir().toString();
       processes.add(new CacheProcess(output,
           null,
-          intDir != null ? intDir : defaultSavantDir,
+          intDir != null ? intDir : savantCache,
           dir != null ? dir : defaultMavenDir));
     }
 

--- a/src/main/java/org/savantbuild/plugin/groovy/BaseGroovyPlugin.java
+++ b/src/main/java/org/savantbuild/plugin/groovy/BaseGroovyPlugin.java
@@ -71,7 +71,7 @@ public class BaseGroovyPlugin extends GroovyObjectSupport implements Plugin {
    * The location pattern is as follows:
    * </p>
    * <pre>
-   *   &lt;user.home&gt;/plugins/&lt;id.group&gt;.&lt;id.name&gt;.properties
+   *   $XDG_CONFIG_HOME/savant/plugins/&lt;id.group&gt;.&lt;id.name&gt;.properties
    * </pre>
    *
    * @param id           The artifact Id that is used to load the configuration file.

--- a/src/main/java/org/savantbuild/runtime/Main.java
+++ b/src/main/java/org/savantbuild/runtime/Main.java
@@ -38,6 +38,7 @@ import org.savantbuild.parser.groovy.GroovyBuildFileParser;
 import org.savantbuild.plugin.PluginLoadException;
 import org.savantbuild.security.MD5Exception;
 import org.savantbuild.util.CyclicException;
+import org.savantbuild.util.SavantPaths;
 
 import static java.util.Arrays.asList;
 
@@ -61,6 +62,8 @@ public class Main {
     if (runtimeConfiguration.debug) {
       output.enableDebug();
     }
+
+    SavantPaths.get().migrate(output);
 
     Path buildFile = projectDir.resolve("build.savant");
     if (!Files.isRegularFile(buildFile) || !Files.isReadable(buildFile)) {

--- a/src/main/shell/release-int.sh
+++ b/src/main/shell/release-int.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-name="savant-core"
-version="0.2.0-{integration}"
-cp src/main/resources/amd.xml ~/.savant/cache/org/savantbuild/${name}/${version}/${name}-${version}.jar.amd
-cd ~/.savant/cache/org/savantbuild/${name}/${version}/
-md5sum ${name}-${version}.jar > ${name}-${version}.jar.md5
-md5sum ${name}-${version}.jar.amd > ${name}-${version}.jar.amd.md5
-md5sum ${name}-${version}-src.jar > ${name}-${version}-src.jar.md5

--- a/src/test/java/org/savantbuild/parser/groovy/GroovyBuildFileParserTest.java
+++ b/src/test/java/org/savantbuild/parser/groovy/GroovyBuildFileParserTest.java
@@ -45,6 +45,7 @@ import org.savantbuild.parser.ParseException;
 import org.savantbuild.runtime.RuntimeConfiguration;
 import org.savantbuild.util.Graph;
 import org.savantbuild.util.HashGraph;
+import org.savantbuild.util.SavantPaths;
 import org.testng.annotations.Test;
 
 import groovy.lang.MissingPropertyException;
@@ -98,12 +99,12 @@ public class GroovyBuildFileParserTest extends BaseUnitTest {
     // Verify the workflow
     assertEquals(project.workflow.fetchWorkflow.processes.size(), 4);
     assertTrue(project.workflow.fetchWorkflow.processes.get(0) instanceof CacheProcess);
-    assertEquals(((CacheProcess) project.workflow.fetchWorkflow.processes.get(0)).savantDir, System.getProperty("user.home") + "/.savant/cache");
-    assertEquals(((CacheProcess) project.workflow.fetchWorkflow.processes.get(0)).integrationDir, System.getProperty("user.home") + "/.savant/cache");
+    assertEquals(((CacheProcess) project.workflow.fetchWorkflow.processes.get(0)).savantDir, SavantPaths.get().cacheDir().toString());
+    assertEquals(((CacheProcess) project.workflow.fetchWorkflow.processes.get(0)).integrationDir, SavantPaths.get().cacheDir().toString());
     assertEquals(((CacheProcess) project.workflow.fetchWorkflow.processes.get(0)).mavenDir, System.getProperty("user.home") + "/.m2/repository");
     assertTrue(project.workflow.fetchWorkflow.processes.get(1) instanceof CacheProcess);
     assertEquals(((CacheProcess) project.workflow.fetchWorkflow.processes.get(1)).mavenDir, System.getProperty("user.home") + "/.m2/repository");
-    assertEquals(((CacheProcess) project.workflow.fetchWorkflow.processes.get(1)).integrationDir, System.getProperty("user.home") + "/.savant/cache");
+    assertEquals(((CacheProcess) project.workflow.fetchWorkflow.processes.get(1)).integrationDir, SavantPaths.get().cacheDir().toString());
     assertEquals(((URLProcess) project.workflow.fetchWorkflow.processes.get(2)).url, "https://repository.savantbuild.org");
     assertEquals(((URLProcess) project.workflow.fetchWorkflow.processes.get(2)).username, "username");
     assertEquals(((URLProcess) project.workflow.fetchWorkflow.processes.get(2)).password, "password");
@@ -111,11 +112,11 @@ public class GroovyBuildFileParserTest extends BaseUnitTest {
     assertEquals(((MavenProcess) project.workflow.fetchWorkflow.processes.get(3)).username, "username");
     assertEquals(((MavenProcess) project.workflow.fetchWorkflow.processes.get(3)).password, "password");
     assertEquals(project.workflow.publishWorkflow.processes.size(), 2);
-    assertEquals(((CacheProcess) project.workflow.publishWorkflow.processes.get(0)).savantDir, System.getProperty("user.home") + "/.savant/cache");
-    assertEquals(((CacheProcess) project.workflow.publishWorkflow.processes.get(0)).integrationDir, System.getProperty("user.home") + "/.savant/cache");
+    assertEquals(((CacheProcess) project.workflow.publishWorkflow.processes.get(0)).savantDir, SavantPaths.get().cacheDir().toString());
+    assertEquals(((CacheProcess) project.workflow.publishWorkflow.processes.get(0)).integrationDir, SavantPaths.get().cacheDir().toString());
     assertEquals(((CacheProcess) project.workflow.publishWorkflow.processes.get(0)).mavenDir, System.getProperty("user.home") + "/.m2/repository");
     assertEquals(((CacheProcess) project.workflow.publishWorkflow.processes.get(1)).mavenDir, System.getProperty("user.home") + "/.m2/repository");
-    assertEquals(((CacheProcess) project.workflow.publishWorkflow.processes.get(1)).integrationDir, System.getProperty("user.home") + "/.savant/cache");
+    assertEquals(((CacheProcess) project.workflow.publishWorkflow.processes.get(1)).integrationDir, SavantPaths.get().cacheDir().toString());
 
     // Version mappings
     Map<String, Version> expectedMappings = new HashMap<>();


### PR DESCRIPTION
## Summary
- Replace all hardcoded `~/.savant/` paths with `SavantPaths.get()` calls for XDG compliance
- `WorkflowDelegate`: Remove `defaultSavantDir` field, use `SavantPaths.get().cacheDir()` inline
- `Project`: Plugin config directory now resolves via `SavantPaths.get().configDir()`
- `GlobalConfiguration`: Config file path and error messages use dynamic XDG paths
- `Main.java`: Add `SavantPaths.get().migrate(output)` call on startup for automatic migration from `~/.savant/`
- Remove obsolete `release-int.sh` script
- Update test assertions for new cache paths

## Test plan
- [x] `sb test` passes (19 tests, 0 failures)
- [x] All `GroovyBuildFileParserTest` assertions updated for XDG paths
- [x] Migration runs automatically before any build file parsing